### PR TITLE
fix: hide loading spinner when connected

### DIFF
--- a/src/components/connect-button.ts
+++ b/src/components/connect-button.ts
@@ -82,7 +82,7 @@ export class ConnectButton extends LitElement {
       ${this.loading ? 'no-logo' : ''} 
       ${this.connected ? 'gradient' : ''}
     `
-    const smallLoadingIndicator = this.loading
+    const smallLoadingIndicator = this.loading && !this.connected
       ? html`<loading-spinner class="small"></loading-spinner>`
       : ''
 


### PR DESCRIPTION
This will ensure that the loading spinner is not displayed once a connection is established.