### PR TITLE
fix: prevent compact mode when scaling

### DIFF
--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -255,7 +255,7 @@ export class RadixButton extends LitElement {
         outline: 0px auto -webkit-focus-ring-color;
       }
 
-      @container (width < ${BUTTON_MIN_WIDTH}px) {
+      @container (width < ${BUTTON_MIN_WIDTH - 0.1}px) {
         button {
           width: var(--radix-connect-button-height, 40px);
           max-width: ${BUTTON_MIN_WIDTH}px;

--- a/src/components/connect-button.ts
+++ b/src/components/connect-button.ts
@@ -262,6 +262,7 @@ export class ConnectButton extends LitElement {
       text-align: left;
       font-family: 'IBM Plex Sans';
       position: relative;
+      z-index: 1000;
       display: inline-block;
 
       /* Core colors */

--- a/src/components/pages/sharing.ts
+++ b/src/components/pages/sharing.ts
@@ -100,6 +100,7 @@ export class RadixSharingPage extends LitElement {
       }
       .content {
         max-height: 193px;
+        overflow-x: hidden;
       }
       .buttons {
         display: grid;


### PR DESCRIPTION
When scaling, sometimes browser rounds container to have `.99` instead of full number. With this fix it's not a problem anymore because we're still treating it like a full number